### PR TITLE
Update 00-hypr-pkgs.sh

### DIFF
--- a/install-scripts/00-hypr-pkgs.sh
+++ b/install-scripts/00-hypr-pkgs.sh
@@ -45,7 +45,8 @@ wget
 wl-clipboard
 wlogout
 xdg-user-dirs
-xdg-utils 
+xdg-utils
+xorg-xhost
 yad
 )
 


### PR DESCRIPTION
fix: apps not run with sudo on wayland

# Pull Request

## Description

Install the 'xorg-xhost' package by default for under wayland apps to work

## Type of change

- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] I have tested my code locally and it works as expected.