### PR TITLE
fix: fix infinte loop when prompting for SDDM themes

### DIFF
--- a/install-scripts/sddm.sh
+++ b/install-scripts/sddm.sh
@@ -96,6 +96,7 @@ while [ "$valid_input" != true ]; do
     valid_input=true
   else
     printf "\n%s - Invalid input. Please enter 'y' for Yes or 'n' for No.\n" "${ERROR}" 2>&1 | tee -a "$LOG"
+    install_sddm_theme=""
   fi
 done
 


### PR DESCRIPTION
# Pull Request

## Description

As I was running the script on my VM, I hit <kbd>x</kbd> instead of <kbd>y</kbd> and got stuck in an infinite loop. 
Resetting the prompt variable (`install_sddm_theme`) fix the issue.
I haven't checked if the issue was present elsewhere in the scripts. 

## Type of change

Please put an `x` in the boxes that apply:

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Arch-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Additional context

Tested locally with a minimal reproducible example
```sh

# SDDM-themes
valid_input=false
while [ "$valid_input" != true ]; do
  if [[ -z $install_sddm_theme ]]; then
    read -n 1 -r -p "OPTIONAL - Would you like to install SDDM themes? (y/n)" install_sddm_theme
  fi
  if [[ $install_sddm_theme =~ ^[Yy]$ ]]; then
    printf "\n%s - Installing Simple SDDM Theme\n"
    valid_input=true
  elif [[ $install_sddm_theme =~ ^[Nn]$ ]]; then
    printf "\n%s - No SDDM themes will be installed.\n"
    valid_input=true
  else
    printf "\n%s - Invalid input. Please enter 'y' for Yes or 'n' for No.\n"
    # uncomment for the fix
    # install_sddm_theme=""
  fi
done
```
