### PR TITLE
feat: Use oh-my-posh prompt with illusi0n theme

### DIFF
--- a/assets/.oh-my-posh/illusi0n.omp.json
+++ b/assets/.oh-my-posh/illusi0n.omp.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "segments": [
+        {
+          "foreground": "#ff8800",
+          "style": "diamond",
+          "template": "{{ round .PhysicalPercentUsed .Precision }}% ",
+          "type": "sysinfo"
+        },
+        {
+          "foreground": "#ff8800",
+          "style": "diamond",
+          "template": "{{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB ",
+          "type": "sysinfo"
+        }
+      ],
+      "type": "rprompt"
+    },
+    {
+      "alignment": "left",
+      "segments": [
+        {
+          "foreground": "#ff8800",
+          "properties": {
+            "macos": "mac"
+          },
+          "style": "plain",
+          "template": "{{ if .WSL }}WSL at {{ end }}{{.Icon}} ",
+          "type": "os"
+        },
+        {
+          "foreground": "#ff8800",
+          "style": "plain",
+          "template": "$",
+          "type": "text"
+        },
+        {
+          "foreground": "#ff8800",
+          "style": "plain",
+          "template": "{{ .UserName }}:",
+          "type": "session"
+        },
+        {
+          "foreground": "#62c0ff",
+          "properties": {
+            "folder_separator_icon": "/",
+            "style": "full"
+          },
+          "style": "plain",
+          "type": "path"
+        },
+        {
+          "foreground": "#62c0ff",
+          "foreground_templates": [
+            "{{ if or (.Working.Changed) (.Staging.Changed) }}#6287ff{{ end }}",
+            "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#7f62ff{{ end }}",
+            "{{ if gt .Ahead 0 }}#9962ff{{ end }}",
+            "{{ if gt .Behind 0 }}#c062ff{{ end }}"
+          ],
+          "properties": {
+            "branch_max_length": 25,
+            "fetch_stash_count": true,
+            "fetch_status": true,
+            "fetch_upstream_icon": true
+          },
+          "style": "plain",
+          "template": "<#ff8800>on</> {{.UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+          "type": "git"
+        },
+        {
+          "foreground": "#ff8800",
+          "style": "plain",
+          "template": "\u276f ",
+          "type": "text"
+        }
+      ],
+      "type": "prompt"
+    }
+  ],
+  "version": 2
+}

--- a/assets/.zshrc
+++ b/assets/.zshrc
@@ -33,3 +33,5 @@ HISTFILE=~/.zsh_history
 HISTSIZE=10000
 SAVEHIST=10000
 setopt appendhistory
+
+eval "$(oh-my-posh init zsh --config ~/.oh-my-posh/illusi0n.omp.json)"

--- a/install-scripts/zsh.sh
+++ b/install-scripts/zsh.sh
@@ -10,6 +10,8 @@ zsh=(
 	zsh
 	zsh-completions
 	fzf
+	oh-my-posh-bin
+	ttf-meslo-nerd
 )
 
 
@@ -77,7 +79,7 @@ if command -v zsh >/dev/null; then
 	else
     	echo "Directory zsh-syntax-highlighting already exists. Skipping cloning." 2>&1 | tee -a "$LOG"
 	fi
-	
+
 	# Check if ~/.zshrc and .zprofile exists, create a backup, and copy the new configuration
 	if [ -f "$HOME/.zshrc" ]; then
     	cp -b "$HOME/.zshrc" "$HOME/.zshrc-backup" || true
@@ -86,7 +88,7 @@ if command -v zsh >/dev/null; then
 	if [ -f "$HOME/.zprofile" ]; then
     	cp -b "$HOME/.zprofile" "$HOME/.zprofile-backup" || true
 	fi
-	
+
 	# Copying the preconfigured zsh themes and profile
     cp -r 'assets/.zshrc' ~/
     cp -r 'assets/.zprofile' ~/
@@ -99,6 +101,8 @@ if command -v zsh >/dev/null; then
 	done
 	printf "${NOTE} Shell changed successfully to zsh.\n" 2>&1 | tee -a "$LOG"
 
+	# Copying the preconfigured oh-my-posh theme
+    cp -r 'assets/.oh-my-posh' ~/
 fi
 
 clear


### PR DESCRIPTION
Change-Id: I59745b68cf3102526de198c9955694652973a54b

# Pull Request

## Description

- Uses oh-my-posh prompt on top of oh-my-zsh with illusi0n theme.

REQUIRES: https://github.com/JaKooLit/Hyprland-Dots/pull/376

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Arch-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.

## Screenshots

![image](https://github.com/JaKooLit/Arch-Hyprland/assets/76483474/3de78dc8-1727-4893-a9b4-9e75fbeae077)
