### PR TITLE
fix: Fix wlogout not being installed

### DIFF
--- a/install-scripts/00-hypr-pkgs.sh
+++ b/install-scripts/00-hypr-pkgs.sh
@@ -47,7 +47,7 @@ wallust-git
 waybar
 wget
 wl-clipboard
-wlogout
+wlogout-git
 xdg-user-dirs
 xdg-utils 
 yad


### PR DESCRIPTION
After running the install script on a fresh and minimal arch installation, I noticed that after clicking on the power button on the waybar nothing happens.

Trying to solve this I looked what script it was supposed to run when clicked, after running the _**~/.config/hypr/scripts/Wlogout.sh**_ manually it says that wlogout isn't installed.

Maybe wlogout wasn't installed by running your latest script for some reason, I tried to install it from aur using yay but it complains about being unable to import some PGP key, I solved it by install the wlogout-git package instead of the wlogout package.