### PR TITLE
Fix missing monitor scripts from Fedora-Hyprland PR #234

### DIFF
--- a/install-scripts/battery-monitor.sh
+++ b/install-scripts/battery-monitor.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Battery Monitor and Low Battery Notification #
+
+battery=(
+  acpi
+  libnotify
+)
+
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_battery-monitor.log"
+
+# Battery Monitor
+printf "${NOTE} Installing ${SKY_BLUE}Battery Monitor${RESET} Packages...\n"
+for BAT in "${battery[@]}"; do
+  install_package "$BAT" "$LOG"
+done
+
+# Create battery monitoring script
+printf "${NOTE} Creating ${YELLOW}battery monitoring${RESET} script...\n"
+
+BATTERY_SCRIPT="$HOME/.config/hypr/scripts/battery-monitor.sh"
+mkdir -p "$HOME/.config/hypr/scripts"
+
+cat > "$BATTERY_SCRIPT" << 'EOF'
+#!/bin/bash
+# Low Battery Notification Script
+# Monitors battery level and sends notifications
+
+# Configuration
+LOW_BATTERY_THRESHOLD=20
+CRITICAL_BATTERY_THRESHOLD=10
+CHECK_INTERVAL=60  # Check every 60 seconds
+
+# Track notification state to avoid spam
+NOTIFIED_LOW=false
+NOTIFIED_CRITICAL=false
+
+while true; do
+    # Get battery percentage
+    BATTERY_LEVEL=$(acpi -b | grep -P -o '[0-9]+(?=%)')
+    BATTERY_STATUS=$(acpi -b | grep -o 'Discharging\|Charging\|Full')
+    
+    # Only send notifications when discharging
+    if [ "$BATTERY_STATUS" = "Discharging" ]; then
+        if [ "$BATTERY_LEVEL" -le "$CRITICAL_BATTERY_THRESHOLD" ] && [ "$NOTIFIED_CRITICAL" = false ]; then
+            notify-send -u critical -i battery-caution "Critical Battery" "Battery level is at ${BATTERY_LEVEL}%! Please plug in your charger immediately."
+            NOTIFIED_CRITICAL=true
+            NOTIFIED_LOW=true
+        elif [ "$BATTERY_LEVEL" -le "$LOW_BATTERY_THRESHOLD" ] && [ "$NOTIFIED_LOW" = false ]; then
+            notify-send -u normal -i battery-low "Low Battery" "Battery level is at ${BATTERY_LEVEL}%. Consider plugging in your charger."
+            NOTIFIED_LOW=true
+        fi
+    else
+        # Reset notification flags when charging or full
+        NOTIFIED_LOW=false
+        NOTIFIED_CRITICAL=false
+    fi
+    
+    sleep "$CHECK_INTERVAL"
+done
+EOF
+
+chmod +x "$BATTERY_SCRIPT"
+
+printf "${OK} Battery monitoring script created at ${YELLOW}$BATTERY_SCRIPT${RESET}\n"
+
+# Create systemd user service
+printf "${NOTE} Creating ${YELLOW}systemd user service${RESET} for battery monitoring...\n"
+
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+mkdir -p "$SYSTEMD_DIR"
+
+cat > "$SYSTEMD_DIR/battery-monitor.service" << EOF
+[Unit]
+Description=Battery Level Monitor
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=$BATTERY_SCRIPT
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+printf "${OK} Systemd service created\n"
+
+# Enable and start the service
+printf "${NOTE} Enabling and starting ${YELLOW}battery-monitor${RESET} service...\n"
+systemctl --user daemon-reload
+systemctl --user enable battery-monitor.service 2>&1 | tee -a "$LOG"
+systemctl --user start battery-monitor.service 2>&1 | tee -a "$LOG"
+
+printf "${OK} Battery monitor service is now running!\n"
+printf "${INFO} You can check status with: ${YELLOW}systemctl --user status battery-monitor${RESET}\n"
+printf "${INFO} To stop: ${YELLOW}systemctl --user stop battery-monitor${RESET}\n"
+printf "${INFO} To disable: ${YELLOW}systemctl --user disable battery-monitor${RESET}\n"
+
+printf "\n%.0s" {1..2}

--- a/install-scripts/disk-monitor.sh
+++ b/install-scripts/disk-monitor.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Disk Space Monitor #
+
+disk=(
+  libnotify
+)
+
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_disk-monitor.log"
+
+# Disk Monitor
+printf "${NOTE} Installing ${SKY_BLUE}Disk Monitor${RESET} Packages...\n"
+for DISK in "${disk[@]}"; do
+  install_package "$DISK" "$LOG"
+done
+
+# Create disk monitoring script
+printf "${NOTE} Creating ${YELLOW}disk space monitoring${RESET} script...\n"
+
+DISK_SCRIPT="$HOME/.config/hypr/scripts/disk-monitor.sh"
+mkdir -p "$HOME/.config/hypr/scripts"
+
+cat > "$DISK_SCRIPT" << 'EOF'
+#!/bin/bash
+# Disk Space Monitoring Script
+# Monitors disk usage and sends notifications
+
+# Configuration
+DISK_WARNING_THRESHOLD=80
+DISK_CRITICAL_THRESHOLD=90
+CHECK_INTERVAL=300  # Check every 5 minutes
+
+# Track notification state
+declare -A NOTIFIED_WARNING
+declare -A NOTIFIED_CRITICAL
+
+while true; do
+    # Get disk usage for all mounted filesystems
+    df -h | grep '^/dev/' | while read -r line; do
+        DEVICE=$(echo "$line" | awk '{print $1}')
+        MOUNT=$(echo "$line" | awk '{print $6}')
+        USAGE=$(echo "$line" | awk '{print $5}' | sed 's/%//')
+        
+        # Skip if usage is not a number
+        if ! [[ "$USAGE" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
+        
+        # Check disk usage
+        if [ "$USAGE" -ge "$DISK_CRITICAL_THRESHOLD" ]; then
+            if [ "${NOTIFIED_CRITICAL[$MOUNT]}" != "true" ]; then
+                notify-send -u critical -i drive-harddisk "Critical Disk Space" "Mount point $MOUNT is ${USAGE}% full!\nDevice: $DEVICE"
+                NOTIFIED_CRITICAL[$MOUNT]="true"
+                NOTIFIED_WARNING[$MOUNT]="true"
+            fi
+        elif [ "$USAGE" -ge "$DISK_WARNING_THRESHOLD" ]; then
+            if [ "${NOTIFIED_WARNING[$MOUNT]}" != "true" ]; then
+                notify-send -u normal -i drive-harddisk "Low Disk Space" "Mount point $MOUNT is ${USAGE}% full\nDevice: $DEVICE"
+                NOTIFIED_WARNING[$MOUNT]="true"
+            fi
+        else
+            # Reset notifications when usage drops
+            if [ "$USAGE" -lt $((DISK_WARNING_THRESHOLD - 5)) ]; then
+                NOTIFIED_WARNING[$MOUNT]="false"
+                NOTIFIED_CRITICAL[$MOUNT]="false"
+            fi
+        fi
+    done
+    
+    sleep "$CHECK_INTERVAL"
+done
+EOF
+
+chmod +x "$DISK_SCRIPT"
+
+printf "${OK} Disk monitoring script created at ${YELLOW}$DISK_SCRIPT${RESET}\n"
+
+# Create systemd user service
+printf "${NOTE} Creating ${YELLOW}systemd user service${RESET} for disk monitoring...\n"
+
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+mkdir -p "$SYSTEMD_DIR"
+
+cat > "$SYSTEMD_DIR/disk-monitor.service" << EOF
+[Unit]
+Description=Disk Space Monitor
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=$DISK_SCRIPT
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+printf "${OK} Systemd service created\n"
+
+# Enable and start the service
+printf "${NOTE} Enabling and starting ${YELLOW}disk-monitor${RESET} service...\n"
+systemctl --user daemon-reload
+systemctl --user enable disk-monitor.service 2>&1 | tee -a "$LOG"
+systemctl --user start disk-monitor.service 2>&1 | tee -a "$LOG"
+
+printf "${OK} Disk monitor service is now running!\n"
+printf "${INFO} You can check status with: ${YELLOW}systemctl --user status disk-monitor${RESET}\n"
+printf "${INFO} View disk usage: ${YELLOW}df -h${RESET}\n"
+
+printf "\n%.0s" {1..2}

--- a/install-scripts/temp-monitor.sh
+++ b/install-scripts/temp-monitor.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# 💫 https://github.com/JaKooLit 💫 #
+# Temperature Monitor - CPU/GPU Temperature Alerts #
+
+temp=(
+  lm_sensors
+  libnotify
+)
+
+
+## WARNING: DO NOT EDIT BEYOND THIS LINE IF YOU DON'T KNOW WHAT YOU ARE DOING! ##
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Change the working directory to the parent directory of the script
+PARENT_DIR="$SCRIPT_DIR/.."
+cd "$PARENT_DIR" || { echo "${ERROR} Failed to change directory to $PARENT_DIR"; exit 1; }
+
+# Source the global functions script
+if ! source "$(dirname "$(readlink -f "$0")")/Global_functions.sh"; then
+  echo "Failed to source Global_functions.sh"
+  exit 1
+fi
+
+# Set the name of the log file to include the current date and time
+LOG="Install-Logs/install-$(date +%d-%H%M%S)_temp-monitor.log"
+
+# Temperature Monitor
+printf "${NOTE} Installing ${SKY_BLUE}Temperature Monitor${RESET} Packages...\n"
+for TEMP in "${temp[@]}"; do
+  install_package "$TEMP" "$LOG"
+done
+
+# Detect sensors
+printf "${NOTE} Detecting ${YELLOW}hardware sensors${RESET}...\n"
+sudo sensors-detect --auto 2>&1 | tee -a "$LOG"
+
+# Create temperature monitoring script
+printf "${NOTE} Creating ${YELLOW}temperature monitoring${RESET} script...\n"
+
+TEMP_SCRIPT="$HOME/.config/hypr/scripts/temp-monitor.sh"
+mkdir -p "$HOME/.config/hypr/scripts"
+
+cat > "$TEMP_SCRIPT" << 'EOF'
+#!/bin/bash
+# Temperature Monitoring Script
+# Monitors CPU and GPU temperatures and sends alerts
+
+# Configuration
+CPU_TEMP_WARNING=75
+CPU_TEMP_CRITICAL=85
+GPU_TEMP_WARNING=75
+GPU_TEMP_CRITICAL=85
+CHECK_INTERVAL=30  # Check every 30 seconds
+
+# Track notification state
+NOTIFIED_CPU_WARN=false
+NOTIFIED_CPU_CRIT=false
+NOTIFIED_GPU_WARN=false
+NOTIFIED_GPU_CRIT=false
+
+while true; do
+    # Get CPU temperature (average of all cores)
+    CPU_TEMP=$(sensors | grep -i 'Package id 0:\|Tdie:' | awk '{print $4}' | sed 's/+//;s/°C//' | head -1)
+    
+    # If Package id not found, try other methods
+    if [ -z "$CPU_TEMP" ]; then
+        CPU_TEMP=$(sensors | grep -i 'Core 0:' | awk '{print $3}' | sed 's/+//;s/°C//' | head -1)
+    fi
+    
+    # Get GPU temperature (if available)
+    GPU_TEMP=$(sensors | grep -i 'edge:\|temp1:' | awk '{print $2}' | sed 's/+//;s/°C//' | head -1)
+    
+    # Check CPU temperature
+    if [ -n "$CPU_TEMP" ]; then
+        CPU_TEMP_INT=${CPU_TEMP%.*}
+        
+        if [ "$CPU_TEMP_INT" -ge "$CPU_TEMP_CRITICAL" ]; then
+            if [ "$NOTIFIED_CPU_CRIT" = false ]; then
+                notify-send -u critical -i temperature-high "Critical CPU Temperature" "CPU temperature is ${CPU_TEMP}°C! System may throttle or shutdown."
+                NOTIFIED_CPU_CRIT=true
+                NOTIFIED_CPU_WARN=true
+            fi
+        elif [ "$CPU_TEMP_INT" -ge "$CPU_TEMP_WARNING" ]; then
+            if [ "$NOTIFIED_CPU_WARN" = false ]; then
+                notify-send -u normal -i temperature-normal "High CPU Temperature" "CPU temperature is ${CPU_TEMP}°C"
+                NOTIFIED_CPU_WARN=true
+            fi
+        else
+            NOTIFIED_CPU_WARN=false
+            NOTIFIED_CPU_CRIT=false
+        fi
+    fi
+    
+    # Check GPU temperature
+    if [ -n "$GPU_TEMP" ]; then
+        GPU_TEMP_INT=${GPU_TEMP%.*}
+        
+        if [ "$GPU_TEMP_INT" -ge "$GPU_TEMP_CRITICAL" ]; then
+            if [ "$NOTIFIED_GPU_CRIT" = false ]; then
+                notify-send -u critical -i temperature-high "Critical GPU Temperature" "GPU temperature is ${GPU_TEMP}°C!"
+                NOTIFIED_GPU_CRIT=true
+                NOTIFIED_GPU_WARN=true
+            fi
+        elif [ "$GPU_TEMP_INT" -ge "$GPU_TEMP_WARNING" ]; then
+            if [ "$NOTIFIED_GPU_WARN" = false ]; then
+                notify-send -u normal -i temperature-normal "High GPU Temperature" "GPU temperature is ${GPU_TEMP}°C"
+                NOTIFIED_GPU_WARN=true
+            fi
+        else
+            NOTIFIED_GPU_WARN=false
+            NOTIFIED_GPU_CRIT=false
+        fi
+    fi
+    
+    sleep "$CHECK_INTERVAL"
+done
+EOF
+
+chmod +x "$TEMP_SCRIPT"
+
+printf "${OK} Temperature monitoring script created at ${YELLOW}$TEMP_SCRIPT${RESET}\n"
+
+# Create systemd user service
+printf "${NOTE} Creating ${YELLOW}systemd user service${RESET} for temperature monitoring...\n"
+
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+mkdir -p "$SYSTEMD_DIR"
+
+cat > "$SYSTEMD_DIR/temp-monitor.service" << EOF
+[Unit]
+Description=Temperature Monitor
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=$TEMP_SCRIPT
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+EOF
+
+printf "${OK} Systemd service created\n"
+
+# Enable and start the service
+printf "${NOTE} Enabling and starting ${YELLOW}temp-monitor${RESET} service...\n"
+systemctl --user daemon-reload
+systemctl --user enable temp-monitor.service 2>&1 | tee -a "$LOG"
+systemctl --user start temp-monitor.service 2>&1 | tee -a "$LOG"
+
+printf "${OK} Temperature monitor service is now running!\n"
+printf "${INFO} You can check status with: ${YELLOW}systemctl --user status temp-monitor${RESET}\n"
+printf "${INFO} View temperatures: ${YELLOW}sensors${RESET}\n"
+
+printf "\n%.0s" {1..2}


### PR DESCRIPTION
This adds the three monitor scripts (battery, disk, temp) that were omitted during porting PR #234 from Fedora-Hyprland.