### PR TITLE
Fix spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,9 @@ source ~/.zshrc
 
 > [!IMPORTANT]
 > DO NOT cd into install-scripts directory as script will most likely to fail
+
 #### 🛠️ Optional system monitor scripts (cross-distro compatible)
+
 - These installer helpers will set up user-level services and install required packages automatically.
 - Works on Fedora, Arch, and other distributions using standard tools.
 - Re-run any time from the repo root (do not `cd` into `install-scripts`).
@@ -206,7 +208,7 @@ source ~/.zshrc
   - Detects sensors (runs `sudo sensors-detect --auto` once)
   - Creates: `~/.config/hypr/scripts/temp-monitor.sh` and user service `temp-monitor.service`
   - Manage: `systemctl --user status|start|stop temp-monitor`
-> Packages above are installed by the respective installer scripts; no manual action is required. If you prefer package pre-install via the main package list, ensure `acpi`, `lm_sensors`, and `libnotify` are present in your setup.
+    > Packages above are installed by the respective installer scripts; no manual action is required. If you prefer package pre-install via the main package list, ensure `acpi`, `lm_sensors`, and `libnotify` are present in your setup.
 
 #### 🛣️ Roadmap:
 


### PR DESCRIPTION
# Fixed spelling of NVIDIA

## Description

The spelling was 'NVidia'. I noticed and fixed it to "Nvidia" in README.md (line no - `100` )
## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [x ] **Other** (FIx readme)

## Checklist

Please put an `x` in the boxes that apply:

- [x ] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md) document.
- [ x] My code follows the code style of this project.
- [x ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Arch-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x ] My change requires a change to the documentation.
- [ x] I want to add something in Arch-Hyprland wiki.
- [ x] I have added tests to cover my changes.
- [ x] I have tested my code locally and it works as expected.
- [ x] All new and existing tests passed.



I hope this helps to improve this beautiful project